### PR TITLE
Do not hardcode the `install` program path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ SWIG = swig
 PKG_CONFIG ?= pkg-config
 PYTHON ?= python3
 
-INSTALL = /usr/bin/install
+INSTALL = install
 INSTALL_PROGRAM = $(INSTALL)
 INSTALL_LIB = $(INSTALL)
 INSTALL_DATA = $(INSTALL) -m 644


### PR DESCRIPTION
On systems that do not use the FHS, such as NixOS, the `install` program
is not located in `/usr/bin/` as its location is dynamic.

`dtc` can be easily installed on such systems by using the `install`
program available in the `$PATH` with:

    make PREFIX=… INSTALL=install

However, this becomes more difficult when `dtc` is being compiled as
part of a larger toolchain, as the toolchain build scripts will not
spontaneously pass such an argument on the command line. This happens
for example when `dtc` is build as a part of the RTEMS build system.

By not hardcoding a predefined path for `install`, as is done for other
executables, `dtc` will allow the one in the `$PATH` to be used.
